### PR TITLE
Implement specialist UI

### DIFF
--- a/apis/HttpClient.ts
+++ b/apis/HttpClient.ts
@@ -18,7 +18,8 @@ export interface Response<T = any> {
   message?: string
   result?: T
   path?: string
-  success?: boolean
+  success?: boolean,
+  stylist?: []
 }
 
 export type MyResponse<T = any> = Promise<Response<T>>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,8 @@ import { useColorScheme } from 'react-native'
 import { Provider } from 'react-redux'
 import { TamaguiProvider } from 'tamagui'
 
+import Specialist from '~/components/organisms/Specialist'
+import SpecialistTemplate from '~/components/templates/SpecialistTemplate'
 import { useAppFonts } from '~/hooks/useAppFonts'
 import useNotifications from '~/hooks/useNotifications'
 import useTranslation, { useInitializeI18n } from '~/hooks/useTranslation'
@@ -55,7 +57,7 @@ function RootLayoutNav (): React.ReactElement {
   return (
     <TamaguiProvider config={config} defaultTheme={colorScheme as any}>
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack>
+         <Stack>
           <Stack.Screen name="index" options={{ headerShown: false }}/>
           <Stack.Screen
             name="(tabs)"

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,9 +4,6 @@ import React, { useEffect } from 'react'
 import { useColorScheme } from 'react-native'
 import { Provider } from 'react-redux'
 import { TamaguiProvider } from 'tamagui'
-
-import Specialist from '~/components/organisms/Specialist'
-import SpecialistTemplate from '~/components/templates/SpecialistTemplate'
 import { useAppFonts } from '~/hooks/useAppFonts'
 import useNotifications from '~/hooks/useNotifications'
 import useTranslation, { useInitializeI18n } from '~/hooks/useTranslation'
@@ -104,6 +101,10 @@ function RootLayoutNav (): React.ReactElement {
             name="combo/StepDetails"
             options={{ headerShown: false }}
           />
+          <Stack.Screen
+            name="checkout/SpecialistCheckout"
+            options={{ headerShown: false }}
+           />
         </Stack>
       </ThemeProvider>
     </TamaguiProvider>

--- a/app/checkout/SpecialistCheckout.tsx
+++ b/app/checkout/SpecialistCheckout.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+import SpecialistTemplate from '~/components/templates/SpecialistTemplate';
+
+const SpecialistCheckout = (): React.ReactElement => <SpecialistTemplate />
+
+export default SpecialistCheckout

--- a/components/atoms/Note.tsx
+++ b/components/atoms/Note.tsx
@@ -1,51 +1,20 @@
-import { useState } from 'react'
-import { useColorScheme } from 'react-native'
-import { Stack, Text, TextArea } from 'tamagui'
+import { TamaguiProvider, Stack, Text, TextArea } from "tamagui";
 
-import getColors from '~/constants/Colors'
-import { useAppFonts } from '~/hooks/useAppFonts'
-import useTranslation from '~/hooks/useTranslation'
-
-interface NotesComponentProps {
-  title?: string
-  placeholder?: string
-  initialValue?: string
-  onSave?: (value: string) => void
-  color?: string
-}
-
-export default function NotesComponent ({
-  title = 'specialist.notes',
-  placeholder = 'Type your notes here',
-  initialValue = ''
-}: NotesComponentProps): JSX.Element {
-  const { fonts } = useAppFonts()
-  const { t } = useTranslation()
-  const [notes, setNotes] = useState(initialValue)
-  const colors = getColors(useColorScheme())
-
+export default function NotesComponent() {
   return (
-    <Stack
-      borderRadius={5}
-      width="93%"
-      alignSelf="center"
-      shadowOpacity={0.1}
-      shadowRadius={5}
-    >
-      <Text marginBottom={8} fontFamily={fonts.JetBrainsMonoBold}>
-        {t(title)}
-      </Text>
-      <TextArea
-        value={notes}
-        onChangeText={setNotes}
-        placeholder={placeholder}
-        width="100%"
-        padding={20}
-        backgroundColor={colors.lightGray}
-        borderRadius={20}
-        height={120}
-        lineHeight={24}
-      />
-    </Stack>
-  )
+    <TamaguiProvider>
+      <Stack padding={10} borderRadius={5}>
+        <Text marginBottom={8}>Notes</Text>
+        <TextArea
+          placeholder="Type your notes here"
+          width="100%"
+          padding={10}
+          backgroundColor="#f0f4f8"
+          borderRadius={10}
+          height={120}
+          lineHeight={24}
+        />
+      </Stack>
+    </TamaguiProvider>
+  );
 }

--- a/components/molecules/Date.tsx
+++ b/components/molecules/Date.tsx
@@ -4,16 +4,17 @@ import { FlatList, StyleSheet, TouchableOpacity, useColorScheme } from 'react-na
 import { Colors } from 'react-native/Libraries/NewAppScreen'
 import { Button, Text, XStack, YStack } from 'tamagui'
 
-import getColors from '~/constants/Colors'
+
 import { useAppFonts } from '~/hooks/useAppFonts'
 import useTranslation from '~/hooks/useTranslation'
+import getColors from '~/constants/Colors'
+
 
 const DateComponent: React.FC = () => {
   const currentDate = new Date()
   const [month, setMonth] = useState<number>(currentDate.getMonth() + 1)
   const [year, setYear] = useState<number>(currentDate.getFullYear())
-  const [days, setDays] =
-  useState<Array<{ day: string, dayOfWeek: string }>>([])
+  const [days, setDays] = useState<Array<{ day: string, dayOfWeek: string }>>([])
   const [selectedDay, setSelectedDay] = useState<string | null>(null)
   const [loading, setLoading] = useState<boolean>(false)
   const { fonts } = useAppFonts()
@@ -31,10 +32,7 @@ const DateComponent: React.FC = () => {
     t('days.saturday')
   ]
 
-  const getAllDaysInMonth = (
-    month: number,
-    year: number
-  ): Array<{ day: string, dayOfWeek: string }> => {
+  const getAllDaysInMonth = (month: number, year: number): Array<{ day: string, dayOfWeek: string }> => {
     if (month >= 1 && month <= 12 && year > 0) {
       const lastDay = new Date(year, month, 0).getDate()
       const daysArray = []
@@ -42,9 +40,7 @@ const DateComponent: React.FC = () => {
       for (let day = 1; day <= lastDay; day++) {
         const dateObj = new Date(year, month - 1, day)
         const dayOfWeek = dayNames[dateObj.getDay()]
-        const formattedDay = `${year}-${month.toString().padStart(2, '0')}-${day
-          .toString()
-          .padStart(2, '0')}`
+        const formattedDay = `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`
         daysArray.push({ day: formattedDay, dayOfWeek })
       }
       return daysArray
@@ -52,17 +48,12 @@ const DateComponent: React.FC = () => {
     return []
   }
 
-  const fetchDataForDays = async (
-    month: number,
-    year: number
-  ): Promise<void> => {
+  const fetchDataForDays = async (month: number, year: number): Promise<void> => {
     setLoading(true)
     const daysList = getAllDaysInMonth(month, year)
 
     try {
-      const fetchedData = await new Promise<
-      Array<{ day: string, dayOfWeek: string }>
-      >((resolve) => {
+      const fetchedData = await new Promise<Array<{ day: string, dayOfWeek: string }>>((resolve) => {
         setTimeout(() => {
           resolve(daysList)
         }, 1000)
@@ -108,16 +99,28 @@ const DateComponent: React.FC = () => {
     setSelectedDay(day === selectedDay ? null : day)
   }
 
+  const formatSelectedDay = (day: string | null): string => {
+    if (day === null || day === '') {
+      return 'No day selected.'
+    }
+
+    const [year, month, dayNumber] = day.split('-')
+    const dateObj = new Date(Number(year), Number(month) - 1, Number(dayNumber))
+    const dayOfWeek = dayNames[dateObj.getDay()]
+
+    return `${dayOfWeek}, ${dayNumber}/${month}/${year}`
+  }
+
   return (
     <YStack padding={16}>
-      <Text fontFamily={fonts.JetBrainsMonoBold}>
-        {t('specialist.date')}
-      </Text>
-      <XStack justifyContent="space-between" alignItems="center" marginTop="5%">
+      <Text>date</Text>
+      <XStack
+        justifyContent="space-between"
+        alignItems="center"
+        marginTop="5%">
         <TouchableOpacity
           onPress={() => { handleMonthChange('prev') }}
-          style={styles.leftAlign}
-        >
+          style={styles.leftAlign}>
           <AntDesign name="left" size={18} color="black" />
         </TouchableOpacity>
 
@@ -133,8 +136,7 @@ const DateComponent: React.FC = () => {
 
         <TouchableOpacity
           onPress={() => { handleMonthChange('next') }}
-          style={styles.rightAlign}
-        >
+          style={styles.rightAlign}>
           <AntDesign name="right" size={18} color="black" />
         </TouchableOpacity>
       </XStack>
@@ -143,48 +145,44 @@ const DateComponent: React.FC = () => {
         ? (<Text>Loading...</Text>)
         : (
           <FlatList
-            data={days}
-            keyExtractor={(item, index) => index.toString()}
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            renderItem={({ item }) => {
-              const dayNumber = item.day.split('-')[2]
-              const isSelected = selectedDay === item.day
-              return (
-                <Button
-                  onPress={() => { handleDayPress(item.day) }}
-                  margin={5}
-                  padding={10}
-                  borderRadius={50}
-                  backgroundColor={isSelected
-                    ? colors.bgDate
-                    : colors.lightGray}
-                  width={55}
-                  height={77}
-                  alignItems="center"
-                  justifyContent="center"
-                  marginTop="$4"
-                >
-                  <YStack>
-                    <Text
-                      fontSize={10}
-                      textAlign="center"
-                      color={isSelected ? Colors.white : colors.textDate}
-                    >
-                      {item.dayOfWeek.slice(0, 8)}
-                    </Text>
-                    <Text
-                      textAlign="center"
-                      fontFamily={fonts.JetBrainsMonoBold}
-                      marginTop={5}
-                      color={isSelected ? colors.white : colors.textDate}
-                    >
-                      {dayNumber}
-                    </Text>
-                  </YStack>
-                </Button>)
-            }}
-          />)}
+          data={days}
+          keyExtractor={(item, index) => index.toString()}
+          horizontal
+          renderItem={({ item }) => {
+            const dayNumber = item.day.split('-')[2]
+            const isSelected = selectedDay === item.day
+            return (
+              <Button
+                onPress={() => { handleDayPress(item.day) }}
+                margin={5}
+                padding={10}
+                borderRadius={50}
+                backgroundColor={isSelected ? '#007B83' : colors.lightGray}
+                width={55}
+                height={77}
+                alignItems="center"
+                justifyContent="center"
+              >
+                <YStack>
+                  <Text fontSize={10} textAlign="center" color={isSelected ? '#FFFFFF' : colors.textDate}>
+                    {item.dayOfWeek.slice(0, 8)}
+                  </Text>
+                  <Text textAlign="center"
+                    fontFamily={fonts.JetBrainsMonoBold}
+                    marginTop={5}
+                    color={isSelected ? '#FFFFFF' : colors.textDate}>
+                    {dayNumber}
+                  </Text>
+                </YStack>
+              </Button>
+            )
+          }}
+        />
+        
+        )}
+
+      
+      <Text>{formatSelectedDay(selectedDay)}</Text>
     </YStack>
   )
 }

--- a/components/molecules/Time.tsx
+++ b/components/molecules/Time.tsx
@@ -1,3 +1,4 @@
+
 import dayjs from 'dayjs'
 import { useState } from 'react'
 import { FlatList, type ListRenderItem } from 'react-native'

--- a/components/molecules/TotalAmount.tsx
+++ b/components/molecules/TotalAmount.tsx
@@ -1,21 +1,28 @@
-import React from 'react'
-import { useColorScheme } from 'react-native'
-import { Text, type TextProps, XStack, YStack } from 'tamagui'
-
-import { PositiveButton } from '~/components/atoms/PositiveButton'
-import getColors from '~/constants/Colors'
-import { useAppFonts } from '~/hooks/useAppFonts'
-import useTranslation from '~/hooks/useTranslation'
+import React from 'react';
+import { useColorScheme } from 'react-native';
+import { Text, type TextProps, XStack, YStack } from 'tamagui';
+import { useRouter } from 'expo-router';
+import { PositiveButton } from '~/components/atoms/PositiveButton';
+import getColors from '~/constants/Colors';
+import { useAppFonts } from '~/hooks/useAppFonts';
+import useTranslation from '~/hooks/useTranslation';
 
 type Props = {
-  price: number
-  deal: number
-} & TextProps
+  price: number;
+  deal: number;
+  specialistdata?: any;
+} & TextProps;
 
 const TotalAmount = (props: Props): JSX.Element => {
-  const colors = getColors(useColorScheme())
-  const { fonts } = useAppFonts()
-  const { t } = useTranslation()
+  const colors = getColors(useColorScheme());
+  const { fonts } = useAppFonts();
+  const { t } = useTranslation();
+  const router = useRouter();
+
+  const redirectToSpecialist = (): void => {
+    router.push('/checkout/SpecialistCheckout');
+  };
+
   return (
     <XStack paddingVertical={16} paddingHorizontal={20} alignItems="center">
       <YStack paddingRight={20} gap={6}>
@@ -29,9 +36,13 @@ const TotalAmount = (props: Props): JSX.Element => {
           </Text>
         </XStack>
       </YStack>
-      <PositiveButton flex={1} title={t('screens.details.bookNow')} />
+      <PositiveButton
+        flex={1}
+        title={t('screens.details.bookNow')}
+        onPress={redirectToSpecialist}
+      />
     </XStack>
-  )
-}
+  );
+};
 
-export default TotalAmount
+export default TotalAmount;

--- a/components/templates/SpecialistTemplate.tsx
+++ b/components/templates/SpecialistTemplate.tsx
@@ -53,7 +53,7 @@ const SpecialistTemplate: React.FC = (): JSX.Element => {
         <Specialist />
         <DateComponent />
         <TimePicker/>
-        <NotesComponent
+        {/* <NotesComponent
           title={t('specialist.notes')}
           placeholder="Write your thoughts here..."
           onSave={(value) => {
@@ -61,7 +61,7 @@ const SpecialistTemplate: React.FC = (): JSX.Element => {
             // Thực hiện lưu trữ hoặc gọi API
           }}
 
-        />
+        /> */}
       </GradientScrollContainer>
 
       <PositiveButton

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -11,12 +11,10 @@ const colors: Record<'light' | 'dark', Colors> = {
     blue: '#235AFF',
     blueOTP: '#898A8D',
     blueSapphire: '#156778',
-
     bookingDetailsBackgroundCard: '#E1F5FA',
     borderInputaOTP: '#21A7C3',
     deepOrange: '#F98600',
     ghostWhite: '#f2f2f2',
-
     gray: '#979797',
     green: '#00EE00',
     inputBackground: '#1C2655',
@@ -45,8 +43,7 @@ const colors: Record<'light' | 'dark', Colors> = {
     text: '#fff',
     textDate: '#979797',
     white: '#FFFFFF',
-    yellow: '#ffff00',
-    textDate :  '#979797'
+    yellow: '#ffff00'
   },
   light: {
     bgDate: '#007B83',
@@ -87,9 +84,9 @@ const colors: Record<'light' | 'dark', Colors> = {
     tealGreen: '#156778',
     text: '#000',
     textDate: '#000',
+
     white: '#FFFFFF',
-    yellow: '#ffff00',
-    textDate :  '#000'
+    yellow: '#ffff00'
   }
 }
 

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -45,7 +45,8 @@ const colors: Record<'light' | 'dark', Colors> = {
     text: '#fff',
     textDate: '#979797',
     white: '#FFFFFF',
-    yellow: '#ffff00'
+    yellow: '#ffff00',
+    textDate :  '#979797'
   },
   light: {
     bgDate: '#007B83',
@@ -87,7 +88,8 @@ const colors: Record<'light' | 'dark', Colors> = {
     text: '#000',
     textDate: '#000',
     white: '#FFFFFF',
-    yellow: '#ffff00'
+    yellow: '#ffff00',
+    textDate :  '#000'
   }
 }
 

--- a/interfaces/Stylist.ts
+++ b/interfaces/Stylist.ts
@@ -10,7 +10,11 @@ export default interface Stylist {
   avatar: string | null
   date_of_birth: string | null
   address: string | null
-  profile: string | null
+  profile: {
+    stylist?: {
+      isWorking: boolean;
+    };
+  } | null
   gender: GenderEnum
   createdAt: string
   updatedAt: string

--- a/locales/en.json
+++ b/locales/en.json
@@ -199,7 +199,7 @@
         "time" : "Time",
         "notes" : "Notes",
         "notification" : "No day selected.",
-        "send" : "Send"
+        "send" : "Payment"
     },
     
         "days": {

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -201,7 +201,7 @@
     "time": "Thời gian",
     "notes": "Ghi chú",
     "notification": "Chưa chọn ngày.",
-    "send": "Gửi"
+    "send": "Thanh toán"
 },
     "days": {
       "sunday": "Chủ Nhật",


### PR DESCRIPTION
## Related issues
Resolved #25 
## Summary
- Create Implement specialist UI includes: 
   + Use React Native's date and time
   + Call API Get All Stylist displays on the screen
   + Dark Mode
   + Update the interface similar to the database return
-  Update color
-  Update key transtion  

## How to test
### step 
1. Open app/_layout.tsx 
2. Commet ``` <TamaguiProvider />```
3. Import tempalte ```import VerifyOTPTemplate from '~/components/templates/SpecialistTemplate'``` 
4. Call ```<SpecialistTemplate/>```

## Concern points
Points to pay attention:
+ From ui need to use API Post Booking for 2 things: 
`date and time = start_time`
`start_time + time of combo = end_time`
![image](https://github.com/user-attachments/assets/3240938d-db5a-4ef1-9220-1d29e5c620b0)
+Do not check the stylist busy or free, cannot check the status of the stylist to set time
![image](https://github.com/user-attachments/assets/e3e70963-afc8-48d0-bfe7-cfefe9bfeded)

## Screenshots
| Light mode | Dark mode |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ddefd2d7-9d69-4fe2-b00f-043c1e907ca2) | ![image](https://github.com/user-attachments/assets/4179936d-9121-4ed2-936a-cd55cc688158) | 




